### PR TITLE
no need to manually require Lib/container.php

### DIFF
--- a/src/app.php
+++ b/src/app.php
@@ -11,8 +11,9 @@ use Psr7Middlewares\Middleware;
  * Create Slim 3.* application, with container
  */
 // Can't extend AppContainer just yet. Have to wait for release 3.1
+// require('Lib/container.php');
 // $app = new \Slim\App(new \App\Lib\AppContainer());
-require('Lib/container.php');
+
 $app = new \Slim\App($c);
 
 $app->add(Middleware::responseTime());


### PR DESCRIPTION
Autoloader should be sufficient from notes on project to resolve dependency for \App\Lib\AppContainer
