### PR TITLE
Slim 3.1 change to app container

### DIFF
--- a/src/app.php
+++ b/src/app.php
@@ -10,10 +10,12 @@ use Psr7Middlewares\Middleware;
 /**
  * Create Slim 3.* application, with container
  */
-// Can't extend AppContainer just yet. Have to wait for release 3.1
-// $app = new \Slim\App(new \App\Lib\AppContainer());
-require('Lib/container.php');
-$app = new \Slim\App($c);
+$app = new \Slim\App(new \App\Lib\AppContainer());
+/*
+ * For Slim < 3.1, (check dependencies if you have problems) uncomment
+ * require('Lib/container.php');
+ * $app = new \Slim\App($c);
+ */
 
 $app->add(Middleware::responseTime());
 $app->add(Middleware::TrailingSlash());


### PR DESCRIPTION
no need to require manually `Lib/container.php`
can now extend the container class, so no need to pass in manual array syntax container
